### PR TITLE
Use secrets.yml and .env instead of secret_token.rb

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VARIABLENAME = value
+

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ doc/
 .DS_Store
 .idea
 .secret
-.env

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,5 +1,14 @@
 development:
   adapter: mysql2
   database: infocoop_dev
-  user: root
-  password:
+  username: root
+  password: 
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: mysql2
+  database: infocoop_test
+  username: root
+  password: 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :application, "infocoop"
 set :repo_url, "git@github.com:marklatham/infocoop.git"
 set :branch, ENV["REVISION"] || ENV["BRANCH_NAME"] || "master"
 
-set :linked_files, %w{config/database.yml config/puma.rb .env}
+set :linked_files, %w{config/database.yml config/secrets.yml config/puma.rb .env}
 set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads}
 
 set :keep_releases, 3

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -11,10 +11,10 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE_DEV"] %>
+  secret_key_base: longrandomstring1setbydeveloper
 
 test:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE_TEST"] %>
+  secret_key_base: longrandomstring2setbydeveloper
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
Does this look like a good way to set up secret_key_base? I followed advice from:

http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#config-secrets-yml 

https://github.com/bkeepers/dotenv-deployment#capistrano-3 
